### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "videointelligence",
     "name_pretty": "Cloud Video Intelligence",
     "product_documentation": "https://cloud.google.com/video-intelligence/docs/",
-    "client_documentation": "https://googleapis.dev/python/videointelligence/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/videointelligence/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/5084810",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ relevant information at the video, shot or per frame.
    :target: https://pypi.org/project/google-cloud-videointelligence/
 .. _Google Cloud Video Intelligence: https://cloud.google.com/video-intelligence/
 .. _Google Cloud Storage: https://cloud.google.com/storage/
-.. _Client Library Documentation: https://googleapis.dev/python/videointelligence/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/videointelligence/latest
 .. _Product Documentation: https://cloud.google.com/video-intelligence/docs/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.