### PR TITLE
fix(deps): require google-api-core >= 1.31.5, >= 2.3.2 on v1 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,9 @@ version = "1.16.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
-dependencies = ["google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",]
+dependencies = [
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
+]
 extras = {}
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ version = "1.16.0"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
-dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
+dependencies = ["google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",]
 extras = {}
 
 


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. Note that this PR is to a new protected branch **v1**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566